### PR TITLE
when a request causes an exception, add CORS headers to respone so th…

### DIFF
--- a/src/lcmap/chipmunk/http.clj
+++ b/src/lcmap/chipmunk/http.clj
@@ -202,10 +202,10 @@
   (-> routes
       (ring-json/wrap-json-body {:keywords? true})
       (ring-json/wrap-json-response)
-      (ring-cors/wrap-cors #".*")
       (ring-defaults/wrap-defaults ring-defaults/api-defaults)
       (ring-keyword-params/wrap-keyword-params)
-      (wrap-exception-handling)))
+      (wrap-exception-handling)
+      (ring-cors/wrap-cors #".*")))
 
 
 ;; ## Encoders


### PR DESCRIPTION
…at error messages are available to requesting agent