### PR TITLE
removed secondary indexes for tiles and layers

### DIFF
--- a/src/lcmap/chipmunk/inventory.clj
+++ b/src/lcmap/chipmunk/inventory.clj
@@ -15,7 +15,8 @@
 (spec/def ::layer string?)
 (spec/def ::source string?)
 (spec/def ::url string?)
-(spec/def ::query (spec/keys :req-un [(or ::tile ::layer ::source ::url)]))
+(spec/def ::search-query (spec/keys :req-un [(or ::source ::url)]))
+(spec/def ::source-query (spec/keys :req-un [(or ::tile ::url)]))
 
 
 (defn insert-source
@@ -64,9 +65,9 @@
 
 
 (defn search
-  "Query inventory by tile, layer, and/or source."
-  [{:keys [:tile :layer :source :url :only] :as params}]
-  (let [params (util/check! ::query (url-to-source params))
+  "Query inventory by source."
+  [{:keys [:source :url :only] :as params}]
+  (let [params (util/check! ::search-query (url-to-source params))
         columns (or (some-> only list flatten) "*")]
     (->> (hayt/select :inventory
                       (hayt/where (dissoc params :only))
@@ -78,7 +79,7 @@
 (defn tile->sources
   "Query inventory materialized view by tile"
   [{:keys [:tile] :as params}]
-  (let [params (util/check! ::query params)
+  (let [params (util/check! ::source-query params)
         columns "*"]
     (->> (hayt/select :inventory_by_tile
                       (hayt/where params)

--- a/src/lcmap/chipmunk/setup.clj
+++ b/src/lcmap/chipmunk/setup.clj
@@ -69,25 +69,6 @@
                                                :extra    :text})))
 
 
-(defn create-inventory-tile-index
-  ""
-  []
-  (hayt/create-index :inventory
-                     :tile
-                     (hayt/index-name :inventory_tile_ix)
-                     (hayt/if-exists false)))
-
-
-(defn create-inventory-layer-index
-  ""
-  []
-  (hayt/create-index :inventory
-                     :layer
-                     (hayt/index-name :inventory_layer_ix)
-                     (hayt/if-exists false)))
-
-
-
 (defn create-inventory-materialized-view
   "Return a map that creates a materialized view from the inventory
   table with a primary key using tile"
@@ -121,10 +102,6 @@
       (alia/execute session (create-inventory))
       (log/debugf "creating grid")
       (alia/execute session (create-grid))
-      (log/debugf "creating inventory's tile index")
-      (alia/execute session (create-inventory-tile-index))
-      (log/debugf "creating inventory's layer index")
-      (alia/execute session (create-inventory-layer-index))
       (log/debugf "creating inventory's materialized view")
       (alia/execute session (create-inventory-materialized-view))
       :done

--- a/test/lcmap/chipmunk/http_test.clj
+++ b/test/lcmap/chipmunk/http_test.clj
@@ -49,18 +49,6 @@
       (is (some? (result :extra)))
       (is (some? (result :chips)))
       (is (= 2500 (count (result :chips))))))
-  (testing "GET /inventory for tile"
-    (let [path "/inventory"
-          tile "027009"
-          resp (shared/go-fish {:url path :query-params {:tile tile}})]
-      (is (= 200 (:status resp)))
-      (is (= 1 (-> resp :body count)))))
-  (testing "GET /inventory for layer"
-    (let [path  "/inventory"
-          query {"layer" "LC08_SRB1"}
-          resp  (shared/go-fish {:url path :query-params query})]
-      (is (= 200 (:status resp)))
-      (is (= 1 (-> resp :body count)))))
   (testing "GET /inventory for source"
     (let [path   "/inventory"
           source "LC08_CU_027009_20130701_20170729_C01_V01_SRB1.tif"

--- a/test/lcmap/chipmunk/inventory_test.clj
+++ b/test/lcmap/chipmunk/inventory_test.clj
@@ -21,14 +21,6 @@
   (let [url (shared/nginx-url "LC08_CU_027009_20130701_20170729_C01_V01_SR.tar/LC08_CU_027009_20130701_20170729_C01_V01_SRB1.tif")
         summary (ingest/save url)]
     (testing "search"
-      (testing "by tile"
-        (let [query {:tile "027009"}
-              result (inventory/search query)]
-          (is (= 1 (count result)))))
-      (testing "by layer"
-        (let [query {:layer "LC08_SRB1"}
-              result (inventory/search query)]
-          (is (= 1 (count result)))))
       (testing "by source id"
         (let [query {:source "LC08_CU_027009_20130701_20170729_C01_V01_SRB1.tif"}
               result (inventory/search query)]


### PR DESCRIPTION
This pull request removes creation of secondary indexes and code that uses them from Chipmunk.  It also removes associated tests.