### PR TITLE
add projection definition as WKT to json used to seed the grid table …

### DIFF
--- a/resources/grid.ak.json
+++ b/resources/grid.ak.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "tile",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",55],PARAMETER[\"standard_parallel_2\",65],PARAMETER[\"latitude_of_center\",50],PARAMETER[\"longitude_of_center\",-154],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 150000.0,
@@ -11,7 +11,7 @@
     },
     {
         "name": "chip",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",55],PARAMETER[\"standard_parallel_2\",65],PARAMETER[\"latitude_of_center\",50],PARAMETER[\"longitude_of_center\",-154],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 3000.0,

--- a/resources/grid.conus.json
+++ b/resources/grid.conus.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "tile",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 150000.0,
@@ -11,7 +11,7 @@
     },
     {
         "name": "chip",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 3000.0,

--- a/resources/grid.hi.json
+++ b/resources/grid.hi.json
@@ -1,7 +1,7 @@
 [
     {
         "name": "tile",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",8],PARAMETER[\"standard_parallel_2\",18],PARAMETER[\"latitude_of_center\",3],PARAMETER[\"longitude_of_center\",-157],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 150000.0,
@@ -11,7 +11,7 @@
     },
     {
         "name": "chip",
-        "proj": null,
+        "proj": "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",8],PARAMETER[\"standard_parallel_2\",18],PARAMETER[\"latitude_of_center\",3],PARAMETER[\"longitude_of_center\",-157],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]",
         "rx": 1.0,
         "ry": -1.0,
         "sx": 3000.0,

--- a/test/lcmap/chipmunk/ingest_test.clj
+++ b/test/lcmap/chipmunk/ingest_test.clj
@@ -113,7 +113,7 @@
         (is (= 1 (:raster-count actual)))
         (is (= 5000 (:raster-x-size actual)))
         (is (= 5000 (:raster-y-size actual)))
-        (is (= "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999957,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]" (:projection actual)))))
+        (is (= "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]" (:projection actual)))))
     (testing "for an invalid source"
       (let [url (shared/nginx-url "wtf.tar/idk.tif")]
         (is (thrown? clojure.lang.ExceptionInfo (gdal-info url)))))))

--- a/test/lcmap/chipmunk/ingest_test.clj
+++ b/test/lcmap/chipmunk/ingest_test.clj
@@ -113,7 +113,7 @@
         (is (= 1 (:raster-count actual)))
         (is (= 5000 (:raster-x-size actual)))
         (is (= 5000 (:raster-y-size actual)))
-        (is (= "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]" (:projection actual)))))
+        (is (= "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999957,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]" (:projection actual)))))
     (testing "for an invalid source"
       (let [url (shared/nginx-url "wtf.tar/idk.tif")]
         (is (thrown? clojure.lang.ExceptionInfo (gdal-info url)))))))

--- a/test/lcmap/chipmunk/ingest_test.clj
+++ b/test/lcmap/chipmunk/ingest_test.clj
@@ -115,7 +115,9 @@
         (is (= 1 (:raster-count actual)))
         (is (= 5000 (:raster-x-size actual)))
         (is (= 5000 (:raster-y-size actual)))
-        (is (string/includes? proj_wkt "Albers,GEOGCS[WGS 84,DATUM[WGS_1984,SPHEROID[WGS 84,6378140,298.25"))))
+        (is (string/includes? proj_wkt "Albers,GEOGCS[WGS 84,DATUM[WGS_1984,SPHEROID[WGS 84,6378140,298.25"))
+        (is (string/includes? proj_wkt "AUTHORITY[EPSG,7030]],AUTHORITY[EPSG,6326]],PRIMEM[Greenwich,0],UNIT[degree,0.0174532925199433],AUTHORITY[EPSG,4326]],PROJECTION[Albers_Conic_Equal_Area],PARAMETER[standard_parallel_1,29.5],PARAMETER[standard_parallel_2,45.5],PARAMETER[latitude_of_center,23],PARAMETER[longitude_of_center,-96],PARAMETER[false_easting,0],PARAMETER[false_northing,0],UNIT[metre,1,AUTHORITY[EPSG,9001]]]"))
+))
     (testing "for an invalid source"
       (let [url (shared/nginx-url "wtf.tar/idk.tif")]
         (is (thrown? clojure.lang.ExceptionInfo (gdal-info url)))))))

--- a/test/lcmap/chipmunk/ingest_test.clj
+++ b/test/lcmap/chipmunk/ingest_test.clj
@@ -1,5 +1,6 @@
 (ns lcmap.chipmunk.ingest-test
   (:require [clojure.test :refer :all]
+            [clojure.string :as string]
             [lcmap.chipmunk.shared :as shared]
             [lcmap.chipmunk.fixtures :as fixtures]
             [lcmap.chipmunk.ingest :refer :all]))
@@ -107,13 +108,14 @@
   (testing "build info from GDAL metadata"
     (testing "for a valid source"
       (let [url (shared/nginx-url "LC08_CU_027009_20130701_20170729_C01_V01_SR.tar/LC08_CU_027009_20130701_20170729_C01_V01_SRB1.tif")
-            actual (gdal-info url)]
+            actual (gdal-info url)
+            proj_wkt (string/replace (:projection actual) "\"" "")]
         (is (= url (:path actual)))
         (is (= [1484415.0 30.0 0.0 1964805.0 0.0 -30.0] (:geo-transform actual)))
         (is (= 1 (:raster-count actual)))
         (is (= 5000 (:raster-x-size actual)))
         (is (= 5000 (:raster-y-size actual)))
-        (is (= "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999957,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]" (:projection actual)))))
+        (is (string/includes? proj_wkt "Albers,GEOGCS[WGS 84,DATUM[WGS_1984,SPHEROID[WGS 84,6378140,298.25"))))
     (testing "for an invalid source"
       (let [url (shared/nginx-url "wtf.tar/idk.tif")]
         (is (thrown? clojure.lang.ExceptionInfo (gdal-info url)))))))

--- a/test/resources/grid.fixture.edn
+++ b/test/resources/grid.fixture.edn
@@ -1,4 +1,5 @@
 [{:name "chip"
+  :proj "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]"
   :rx  1.0
   :ry -1.0
   :sx  3000.0
@@ -6,6 +7,7 @@
   :tx  2565585.0
   :ty  3314805.0}
  {:name "tile"
+  :proj "PROJCS[\"Albers\",GEOGCS[\"WGS 84\",DATUM[\"WGS_1984\",SPHEROID[\"WGS 84\",6378140,298.2569999999986,AUTHORITY[\"EPSG\",\"7030\"]],AUTHORITY[\"EPSG\",\"6326\"]],PRIMEM[\"Greenwich\",0],UNIT[\"degree\",0.0174532925199433],AUTHORITY[\"EPSG\",\"4326\"]],PROJECTION[\"Albers_Conic_Equal_Area\"],PARAMETER[\"standard_parallel_1\",29.5],PARAMETER[\"standard_parallel_2\",45.5],PARAMETER[\"latitude_of_center\",23],PARAMETER[\"longitude_of_center\",-96],PARAMETER[\"false_easting\",0],PARAMETER[\"false_northing\",0],UNIT[\"metre\",1,AUTHORITY[\"EPSG\",\"9001\"]]]"
   :rx  1.0
   :ry -1.0
   :sx  150000.0


### PR DESCRIPTION
…in IWDS

projection definitions were gathered from ARD for HI, AK, and CU using gdal's gdalsrsinfo utility